### PR TITLE
Update cowj to run on gcp

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation 'com.google.cloud:google-cloud-storage:2.22.3'
 
     // fcm
-    implementation 'com.google.firebase:firebase-admin:9.1.1'
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 
     // mysql connector
     implementation 'com.mysql:mysql-connector-j:8.0.33'
@@ -65,6 +65,9 @@ dependencies {
 
 shadowJar {
     archiveBaseName.set('cowj')
+    /// https://stackoverflow.com/questions/55484043/how-to-fix-could-not-find-policy-pick-first-with-google-tts-java-client
+    /// I got this error when I deployed on GCP
+    mergeServiceFiles()
     manifest {
         attributes 'Main-Class' : "cowj.App"
     }


### PR DESCRIPTION
## Changes
1. Update firebase admin sdk vesion
2. Fixed "Could not find policy 'pick_first'" with Google TTS java client?

## Context

There was some issue of some dependency of firebase admin. Something related to SSL. Native code was crashing on Cloud Run. I didn't have full stack trace. Some stackoverflow posts and github issue comments suggested upgrading alpine version and admin sdk version but it didn't help. Finally decided to use amazon linux version of jdk instead of alpine and it worked. But I kept the dependency change anyway because old version had a low impact CVE.

Then I got another error could not find policy and google search suggested adding the line mergeServiceFiles() in shadowJar which fixed the issue