### PR TITLE
Fix #81

### DIFF
--- a/app/src/main/java/cowj/plugins/JWTAuthenticator.java
+++ b/app/src/main/java/cowj/plugins/JWTAuthenticator.java
@@ -188,7 +188,7 @@ public abstract class JWTAuthenticator extends Authenticator.TokenAuthenticator.
          * @return true if it is, false otherwise
          */
         public boolean isSignatureValid() {
-            final String data = encodedHeader + "." + encode(payload);
+            final String data = token.substring(0, token.lastIndexOf('.'));
             final String computed = hmacSha256(data, JWTAuthenticator.this.secretKey());
             return signature.equals(computed); //signature matched
         }


### PR DESCRIPTION
# Problem

Signature verification was incorrect. It was re encoding the payload and computing the signature. Problem is this re encoding did not preserve the original formatting of the json. While order and spaces dont matter to parse json, it changes the signature which changes the hash if formatting and order are not preserved.

# Solution

Extract header and payload from original token instead of trying to encode the extracted json